### PR TITLE
Increase base html font size by 1px

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,9 @@
 @layer theme, base, clerk, components, utilities; /* Ensure Clerk is compatible with Tailwind CSS v4 */
 
 @import 'tailwindcss';
+
+@layer base {
+  html {
+    font-size: 17px;
+  }
+}


### PR DESCRIPTION
## Summary
- set the base html font-size to 17px to increase typography by 1px globally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f1a350722c8322a4aba4ca963aa805